### PR TITLE
[MO] - @versioning -> file to store current supported versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+
+# MacOS related
+.DS_Store

--- a/kafka_versions.yaml
+++ b/kafka_versions.yaml
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "kafkaVersions": {
-    "2.8.1": "test-container:latest-kafka-2.8.1"
+    "2.8.1": "test-container:latest-kafka-2.8.1",
     "3.0.0": "test-container:latest-kafka-3.0.0"
   }
 }

--- a/kafka_versions.yaml
+++ b/kafka_versions.yaml
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "kafkaVersions": {
+    "2.8.1": "test-container:latest-kafka-2.8.1"
+    "3.0.0": "test-container:latest-kafka-3.0.0"
+  }
+}

--- a/kafka_versions.yaml
+++ b/kafka_versions.yaml
@@ -1,3 +1,4 @@
+# kafka_versions.yaml file stores current supported Kafka versions, which are used in https://github.com/strimzi/test-container/ repository
 {
   "version": 1,
   "kafkaVersions": {

--- a/kafka_versions.yaml
+++ b/kafka_versions.yaml
@@ -1,4 +1,10 @@
-# kafka_versions.yaml file stores current supported Kafka versions, which are used in https://github.com/strimzi/test-container/ repository
+# kafka_versions.yaml file stores current supported Kafka versions, which are used in https://github.com/strimzi/test-container/
+# repository. Moreover, in the test-container code, we fetch this file during test execution in order to decide what's the
+# "latest" version, and what images should be used for a given version. Lastly, one additional information about branches relation:
+#  BRANCH RELATION
+#       test-container repo `main` branch <--fetches--> test-container-images `main` branch file
+#       test-container repo `release` branch <--fetches--> test-container-images `release` branch file
+#
 {
   "version": 1,
   "kafkaVersions": {


### PR DESCRIPTION
Signed-off-by: morsak <xorsak02@stud.fit.vutbr.cz>

This PR adds `kafka_versions.yaml` which stores current supported Kafka versions in https://github.com/strimzi/test-container repository and specifically for this logic (https://github.com/strimzi/test-container/pull/7).