### PR TITLE
Add support for Power arch (ppc64le)

### DIFF
--- a/.azure/build_pipeline.yaml
+++ b/.azure/build_pipeline.yaml
@@ -36,11 +36,11 @@ jobs:
         displayName: "Build images"
         env:
           DOCKER_BUILDKIT: 1
-          ARCHS: 'amd64 s390x arm64'
+          ARCHS: 'amd64 s390x arm64 ppc64le'
       - bash: make docker_tag_push
         condition: and(succeeded(), or(eq(variables['build.sourceBranch'], 'refs/heads/main'), startsWith(variables['build.sourceBranch'], 'refs/tags/')))
         displayName: "Tag and push images"
         env:
           QUAY_USER: $(QUAY_USER)
           QUAY_PASS: $(QUAY_PASS)
-          ARCHS: 'amd64 s390x arm64'
+          ARCHS: 'amd64 s390x arm64 ppc64le'


### PR DESCRIPTION
Adding support for IBM Power (ppc64le) arch to the test-container images.

Signed-off-by: Abhijit Mane <abhijman@in.ibm.com>