### PR TITLE
Update vm image to build

### DIFF
--- a/.azure/build_pipeline.yaml
+++ b/.azure/build_pipeline.yaml
@@ -20,7 +20,7 @@ jobs:
     timeoutInMinutes: 60
     # Base system
     pool:
-      vmImage: 'Ubuntu-18.04'
+      vmImage: 'Ubuntu-22.04'
     # Pipeline steps
     steps:
       # Install Prerequisites


### PR DESCRIPTION
This PR updates a version of the VM image build because the image (`Ubuntu-18.04`) was removed.