### PR TITLE
Cache only kafka_binaries dir

### DIFF
--- a/.azure/build_pipeline.yaml
+++ b/.azure/build_pipeline.yaml
@@ -27,7 +27,7 @@ jobs:
       - template: "./install_docker.yaml"
       - task: Cache@2
         inputs:
-          key: '"kafka_binaries_v2"'
+          key: '"kafka_binaries_v3"'
           path: images/kafka_binaries
         displayName: Kafka Binaries cache
       - bash: make prepare

--- a/.azure/build_pipeline.yaml
+++ b/.azure/build_pipeline.yaml
@@ -28,7 +28,7 @@ jobs:
       - task: Cache@2
         inputs:
           key: '"kafka_binaries_v2"'
-          path: images
+          path: images/kafka_binaries
         displayName: Kafka Binaries cache
       - bash: make prepare
         displayName: "Download kafka"


### PR DESCRIPTION
This PR changes how we cache the images directory. Currently, we cached the whole directory, which is wrong because when we modify Dockefiles inside it, it builds images from the cached Dockefile.