### PR TITLE
Update images to use ubi9

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 USER root
 


### PR DESCRIPTION
This PR changes the current ubi8 base image and replaces it with ubi9. 