### PR TITLE
Fix permission on kafka-scripts

### DIFF
--- a/.github/actions/build/build-containers/action.yml
+++ b/.github/actions/build/build-containers/action.yml
@@ -23,6 +23,10 @@ runs:
         name: kafka-binaries
         path: images/kafka_binaries/
 
+    - name: Restore execute permissions on Kafka scripts
+      shell: bash
+      run: chmod -R +x images/kafka_binaries/*/bin/
+
     - name: Build base images
       shell: bash
       run: make docker_prepare_base_images


### PR DESCRIPTION
It seems that during GHA migration when downloading `kafka-binaries` we do not execute permissions are lost as in GHA we did split across jobs (in Azure there is just one job). This change should fix it. 

The problem was spotten in `test-container` build where most of the tests failed with:
```java
2026-01-28 09:29:38 ERROR [1:544] Log output from the failed container:
/testcontainers_start.sh: line 2: bin/kafka-storage.sh: Permission denied
/testcontainers_start.sh: line 3: bin/kafka-server-start.sh: Permission denied
```