### PR TITLE
Fix docker manifests push after docker upgrade

### DIFF
--- a/.azure/install_docker.yaml
+++ b/.azure/install_docker.yaml
@@ -3,7 +3,8 @@ steps:
   - task: DockerInstaller@0
     displayName: Docker Installer
     inputs:
-      dockerVersion: 20.10.8
+      # Versions can be found from https://download.docker.com/linux/static/stable/x86_64/
+      dockerVersion: 29.2.0
       releaseType: stable
   - bash: |
       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/images/tag_push_images.sh
+++ b/images/tag_push_images.sh
@@ -38,17 +38,18 @@ $DOCKER_CMD login -u $QUAY_USER -p $QUAY_PASS $REGISTRY
 for KAFKA_VERSION in $KAFKA_VERSIONS
 do
     CURRENT_TAG="$PRODUCT_VERSION-kafka-$KAFKA_VERSION"
-    echo "[INFO] Delete the manifest to the registry, ignore the error if manifest doesn't exist"
-	  $DOCKER_CMD manifest rm $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG || true
     for ARCH in $ARCHITECTURES
     do
         echo "[INFO] Tagging strimzi/$PROJECT_NAME:$CURRENT_TAG-$ARCH to $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG-$ARCH ..."
         $DOCKER_CMD tag strimzi/$PROJECT_NAME:$CURRENT_TAG-$ARCH $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG-$ARCH
         echo "[INFO] Pushing image with name: $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG-$ARCH ..."
 	    $DOCKER_CMD push $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG-$ARCH
-        echo "[INFO] Create / Amend the manifest"
-	    $DOCKER_CMD manifest create $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG --amend $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG-$ARCH
     done
-    echo "[INFO] Push the manifest to the registry"
-	  $DOCKER_CMD manifest push $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG
+    echo "[INFO] Create multi-platform manifest"
+    sources=""
+    for ARCH in $ARCHITECTURES
+    do
+        sources="$sources $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG-$ARCH"
+    done
+    $DOCKER_CMD buildx imagetools create -t $REGISTRY/$REGISTRY_ORGANIZATION/$PROJECT_NAME:$CURRENT_TAG $sources
 done


### PR DESCRIPTION
It seems that github runners updated docker version to 29.1.5 recently. The bumpd from previous version introduced breaking changes for manifest manipulation and because we use quite old approach it starting to fail the builds. This PR switch to use buildx imagetools from manifest manipulation and update syft version to work properly with the docker version.

Same as https://github.com/strimzi/strimzi-kafka-operator/pull/12416