### PR TITLE
Override reusable workflow permissions for build/release to write

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 # Declare default permissions as read only
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 # Declare default permissions as read only
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
Correct the permissions for release and build.yml as top level workflows sets read-only, we need those (i.e., release and build) to have write permissions because of Cosign signing.