### PR TITLE
Switch to branch-based instead of tag-based release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,11 @@ permissions:
 
 jobs:
   release:
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/heads/release-') }}
     uses: ./.github/workflows/reusable-build.yml
     with:
       containerTag: ${{ inputs.releaseVersion }}
+      pushContainers: true
     secrets:
       QUAY_USER: ${{ secrets.QUAY_USER }}
       QUAY_PASS: ${{ secrets.QUAY_PASS }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: 'latest'
+      pushContainers:
+        description: 'Force push containers (used by release workflow)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       QUAY_USER:
         required: false
@@ -59,7 +64,7 @@ jobs:
     name: Push Containers
     needs:
       - build-containers
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ github.ref == 'refs/heads/main' || inputs.pushContainers }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
### Type of change

- Task

### Description

This PR switches our approach of how we handle releases in the tests-container-images and follows the pattern of most Strimzi repos (i.e., branch-based). 

So in this way we should:

1. Push images only in **release pipeline** within `release-*` branches and **main branch**
2. Just regular build in release branch commits

### Checklist

- [ ] Update documentation
- [ ] Update CHANGELOG.md (if present)
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Try your changes inside a Kubernetes cluster, not just from unit tests
- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
